### PR TITLE
fix(ingest): switch to bulk SQL-literal INSERTs to unblock ingest

### DIFF
--- a/tools/ingest/src/d1.ts
+++ b/tools/ingest/src/d1.ts
@@ -41,13 +41,19 @@ export class D1Client {
   }
 
   async execute(sql: string, params?: readonly unknown[]): Promise<D1Result> {
+    // Cloudflare D1 HTTP `/query` rejects `params` on multi-statement SQL (7400).
+    // Omit the `params` key entirely when there is nothing to bind so callers can
+    // send `;`-joined multi-statement scripts (all values inlined as SQL literals)
+    // through the same execute() path.
+    const payload: { sql: string; params?: readonly unknown[] } = { sql };
+    if (params && params.length > 0) payload.params = params;
     const res = await this.fetchImpl(this.endpoint, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.cfg.apiToken}`,
         'content-type': 'application/json',
       },
-      body: JSON.stringify({ sql, params: params ?? [] }),
+      body: JSON.stringify(payload),
     });
     const body = (await res.json()) as D1Response;
     if (!res.ok || !body.success) {

--- a/tools/ingest/src/d1.ts
+++ b/tools/ingest/src/d1.ts
@@ -66,40 +66,19 @@ export class D1Client {
     return first;
   }
 
-  // Cloudflare D1 HTTP `/query` accepts a single `{ sql, params }` object with the
-  // sql field carrying multiple `;`-separated statements. Bind params are shared
-  // across all statements, positioned by `?` placeholders in appearance order. The
-  // response's `result` array contains one entry per executed statement.
+  // Cloudflare D1 HTTP `/query` does not support params + multi-statement together
+  // (code 7400 "params with multiple statements is not supported"). Atomic batching
+  // is only available via the Workers `env.DB.batch(...)` binding, which is not
+  // reachable from Node.js. This helper falls back to serial execution — each
+  // statement gets its own HTTP request. For rebuild-style ingest, a partial
+  // failure is self-healing on the next run (DELETE + re-INSERT).
   async batchAtomic(
     statements: readonly { sql: string; params?: readonly unknown[] }[],
   ): Promise<D1Result[]> {
-    if (statements.length === 0) return [];
-    const sql = statements.map((s) => s.sql).join('; ');
-    const params: unknown[] = [];
+    const results: D1Result[] = [];
     for (const stmt of statements) {
-      if (stmt.params) params.push(...stmt.params);
+      results.push(await this.execute(stmt.sql, stmt.params));
     }
-    const res = await this.fetchImpl(this.endpoint, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.cfg.apiToken}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({ sql, params }),
-    });
-    const body = (await res.json()) as D1Response;
-    if (!res.ok || !body.success) {
-      throw new D1Error({
-        status: res.status,
-        errors: body.errors ?? [{ code: -1, message: 'unknown' }],
-      });
-    }
-    if (!body.result || body.result.length !== statements.length) {
-      throw new D1Error({
-        status: res.status,
-        errors: [{ code: -3, message: `result count mismatch: expected ${statements.length}` }],
-      });
-    }
-    return body.result;
+    return results;
   }
 }

--- a/tools/ingest/src/seed-icons.ts
+++ b/tools/ingest/src/seed-icons.ts
@@ -1,7 +1,11 @@
 import type { D1Client } from './d1.ts';
+import { sqlLiteral } from './sql-literal.ts';
 import type { CollectionSnapshot, IconifyJSON } from './types.ts';
 
-const DEFAULT_BATCH_SIZE = 10;
+// Rows per INSERT statement. D1 HTTP has no hard bind-param ceiling here (we inline
+// values as SQL literals), so this is bounded only by request-body size. 2000 rows
+// at ~200 chars/row ≈ 400 KB per request — well under D1's 100 MB body limit.
+const DEFAULT_BATCH_SIZE = 2000;
 
 type IconMeta = {
   categories: string | null;
@@ -37,10 +41,8 @@ const buildIndex = (body: IconifyJSON): Map<string, IconMeta> => {
   return index;
 };
 
-const buildInsertSql = (rowCount: number): string => {
-  const placeholders = Array.from({ length: rowCount }, () => '(?, ?, ?, ?, ?, ?, ?)').join(', ');
-  return `INSERT INTO icons (collection, name, license, categories, tags, aliases, updated_at) VALUES ${placeholders}`;
-};
+const buildInsertSql = (rows: readonly string[]): string =>
+  `INSERT INTO icons (collection, name, license, categories, tags, aliases, updated_at) VALUES ${rows.join(', ')}`;
 
 export type SeedIconsInput = {
   d1: D1Client;
@@ -58,29 +60,30 @@ export const seedIcons = async (
     const index = buildIndex(snap.body);
     const names = Object.keys(snap.body.icons);
     const updatedAt = Math.floor(Date.now() / 1000);
-    const statements: { sql: string; params: readonly unknown[] }[] = [
-      { sql: 'DELETE FROM icons WHERE collection = ?', params: [snap.collection] },
-    ];
+
+    await input.d1.execute(`DELETE FROM icons WHERE collection = ${sqlLiteral(snap.collection)}`);
+    deleted++;
+
+    if (names.length === 0) continue;
+
     for (let offset = 0; offset < names.length; offset += batchSize) {
       const chunk = names.slice(offset, offset + batchSize);
-      const params: unknown[] = [];
-      for (const name of chunk) {
+      const rows = chunk.map((name) => {
         const meta = index.get(name);
-        params.push(
-          snap.collection,
-          name,
-          snap.license,
-          meta?.categories ?? null,
-          meta?.tags ?? null,
-          meta?.aliases ?? null,
-          updatedAt,
-        );
-      }
-      statements.push({ sql: buildInsertSql(chunk.length), params });
+        const values = [
+          sqlLiteral(snap.collection),
+          sqlLiteral(name),
+          sqlLiteral(snap.license),
+          sqlLiteral(meta?.categories ?? null),
+          sqlLiteral(meta?.tags ?? null),
+          sqlLiteral(meta?.aliases ?? null),
+          sqlLiteral(updatedAt),
+        ].join(', ');
+        return `(${values})`;
+      });
+      const result = await input.d1.execute(buildInsertSql(rows));
+      inserted += result.meta.changes;
     }
-    const results = await input.d1.batchAtomic(statements);
-    deleted++;
-    inserted += results.slice(1).reduce((n, r) => n + r.meta.changes, 0);
   }
   return { deleted, inserted };
 };

--- a/tools/ingest/src/seed-synonyms.ts
+++ b/tools/ingest/src/seed-synonyms.ts
@@ -1,12 +1,12 @@
 import { loadDictionary, type SynonymDictionary } from '@icon-collection/synonyms';
 import type { D1Client } from './d1.ts';
+import { sqlLiteral } from './sql-literal.ts';
 
-const DEFAULT_BATCH_SIZE = 20;
+// Rows per INSERT statement (see seed-icons.ts for rationale).
+const DEFAULT_BATCH_SIZE = 2000;
 
-const buildInsertSql = (rowCount: number): string => {
-  const placeholders = Array.from({ length: rowCount }, () => '(?, ?, ?, ?)').join(', ');
-  return `INSERT INTO synonyms (term, expansion, lang, weight) VALUES ${placeholders}`;
-};
+const buildInsertSql = (rows: readonly string[]): string =>
+  `INSERT INTO synonyms (term, expansion, lang, weight) VALUES ${rows.join(', ')}`;
 
 export type SeedSynonymsInput = {
   d1: D1Client;
@@ -18,18 +18,25 @@ export const seedSynonyms = async (input: SeedSynonymsInput): Promise<{ inserted
   const batchSize = input.batchSize ?? DEFAULT_BATCH_SIZE;
   const dicts = input.dictionaries ?? [loadDictionary('ja'), loadDictionary('en')];
   const entries = dicts.flatMap((d) => Array.from(d));
-  const statements: { sql: string; params: readonly unknown[] }[] = [
-    { sql: 'DELETE FROM synonyms', params: [] },
-  ];
+
+  await input.d1.execute('DELETE FROM synonyms');
+
+  if (entries.length === 0) return { inserted: 0 };
+
+  let inserted = 0;
   for (let offset = 0; offset < entries.length; offset += batchSize) {
     const chunk = entries.slice(offset, offset + batchSize);
-    const params: unknown[] = [];
-    for (const entry of chunk) {
-      params.push(entry.term, entry.expansion, entry.lang, entry.weight ?? 1.0);
-    }
-    statements.push({ sql: buildInsertSql(chunk.length), params });
+    const rows = chunk.map((entry) => {
+      const values = [
+        sqlLiteral(entry.term),
+        sqlLiteral(entry.expansion),
+        sqlLiteral(entry.lang),
+        sqlLiteral(entry.weight ?? 1.0),
+      ].join(', ');
+      return `(${values})`;
+    });
+    const result = await input.d1.execute(buildInsertSql(rows));
+    inserted += result.meta.changes;
   }
-  const results = await input.d1.batchAtomic(statements);
-  const inserted = results.slice(1).reduce((n, r) => n + r.meta.changes, 0);
   return { inserted };
 };

--- a/tools/ingest/src/sql-literal.ts
+++ b/tools/ingest/src/sql-literal.ts
@@ -1,0 +1,19 @@
+// SQL literal serializer for building parameter-less multi-value INSERT statements.
+// Cloudflare D1 HTTP `/query` does not support params + multi-statement (and single
+// statements with thousands of bind params exceed the per-statement limit anyway),
+// so bulk ingest inlines values as escaped SQL literals. All ingested strings come
+// from `@iconify/json` and `@icon-collection/synonyms` — trusted sources — but the
+// escaping is defensive against `'` in icon names, aliases, and category labels.
+
+export const sqlLiteral = (value: unknown): string => {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`sqlLiteral: non-finite number ${value}`);
+    }
+    return String(value);
+  }
+  if (typeof value === 'boolean') return value ? '1' : '0';
+  if (typeof value === 'string') return `'${value.replace(/'/g, "''")}'`;
+  throw new Error(`sqlLiteral: unsupported type ${typeof value}`);
+};

--- a/tools/ingest/tests/d1.test.ts
+++ b/tools/ingest/tests/d1.test.ts
@@ -51,20 +51,17 @@ describe('D1Client.execute', () => {
 });
 
 describe('D1Client.batchAtomic', () => {
-  test('posts statements as JSON array and returns per-statement results', async () => {
-    const seen: unknown[] = [];
-    const fetchImpl = async (url: string, init?: RequestInit) => {
-      seen.push({ url, body: init?.body });
-      return new Response(
-        JSON.stringify({
-          success: true,
-          result: [
-            { success: true, meta: { changes: 3, last_row_id: null }, results: [] },
-            { success: true, meta: { changes: 1, last_row_id: 42 }, results: [] },
-          ],
-        }),
-        { status: 200 },
-      );
+  test('sends one HTTP request per statement and returns per-statement results', async () => {
+    const seen: { body: string }[] = [];
+    let call = 0;
+    const responses = [
+      { success: true, meta: { changes: 3, last_row_id: null }, results: [] },
+      { success: true, meta: { changes: 1, last_row_id: 42 }, results: [] },
+    ];
+    const fetchImpl = async (_url: string, init?: RequestInit) => {
+      seen.push({ body: init?.body as string });
+      const result = responses[call++];
+      return new Response(JSON.stringify({ success: true, result: [result] }), { status: 200 });
     };
     const client = new D1Client(
       { apiToken: 't', accountId: 'a', databaseId: 'd' },
@@ -78,11 +75,13 @@ describe('D1Client.batchAtomic', () => {
       },
     ]);
     expect(results.map((r) => r.meta.changes)).toEqual([3, 1]);
-    const body = JSON.parse((seen[0] as { body: string }).body);
-    expect(body.sql).toBe(
-      'DELETE FROM icons WHERE collection = ?; INSERT INTO icons (id, collection, name, license, updated_at) VALUES (?, ?, ?, ?, ?)',
-    );
-    expect(body.params).toEqual(['mdi', 1, 'mdi', 'home', 'Apache-2.0', 100]);
+    expect(seen).toHaveLength(2);
+    const first = JSON.parse(seen[0]?.body ?? '');
+    expect(first.sql).toBe('DELETE FROM icons WHERE collection = ?');
+    expect(first.params).toEqual(['mdi']);
+    const second = JSON.parse(seen[1]?.body ?? '');
+    expect(second.sql).toContain('INSERT INTO icons');
+    expect(second.params).toEqual([1, 'mdi', 'home', 'Apache-2.0', 100]);
   });
 
   test('throws D1Error on non-success', async () => {

--- a/tools/ingest/tests/run.test.ts
+++ b/tools/ingest/tests/run.test.ts
@@ -1,11 +1,10 @@
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test, vi } from 'vitest';
 import { collectFromPath } from '../src/collect.ts';
-import type { D1Client } from '../src/d1.ts';
+import type { D1Client, D1Result } from '../src/d1.ts';
 import type { R2Client } from '../src/r2.ts';
 import { run } from '../src/run.ts';
 import type { IngestConfig } from '../src/types.ts';
-import { makeFakeBatchAtomic } from './_helpers.ts';
 
 const fixturePath = (name: string): string =>
   fileURLToPath(new URL(`../__fixtures__/${name}`, import.meta.url));
@@ -17,9 +16,17 @@ const baseConfig: IngestConfig = {
   dryRun: false,
 };
 
-const okResult = { success: true, meta: { changes: 0, last_row_id: null }, results: [] };
+const okResult: D1Result = { success: true, meta: { changes: 0, last_row_id: null }, results: [] };
 
-const fakeBatchAtomic = makeFakeBatchAtomic();
+const rowCountFromInsert = (sql: string): number => (sql.match(/\(/g)?.length ?? 0) - 1;
+
+const makeExecute = () =>
+  vi.fn(async (sql: string): Promise<D1Result> => {
+    if (/^\s*INSERT INTO (icons|synonyms)\b/i.test(sql) && !/icons_fts/.test(sql)) {
+      return { ...okResult, meta: { changes: rowCountFromInsert(sql), last_row_id: null } };
+    }
+    return okResult;
+  });
 
 describe('run', () => {
   test('performs detect -> collect -> sync-r2 -> seed-d1 and returns a report', async () => {
@@ -27,10 +34,7 @@ describe('run', () => {
       putJson: vi.fn(async () => ({ changed: true, sha256: 'x' })),
       getJson: vi.fn(async () => null),
     } as unknown as R2Client;
-    const d1 = {
-      execute: vi.fn(async () => okResult),
-      batchAtomic: vi.fn(fakeBatchAtomic),
-    } as unknown as D1Client;
+    const d1 = { execute: makeExecute() } as unknown as D1Client;
     const report = await run(baseConfig, {
       r2,
       d1,
@@ -53,10 +57,7 @@ describe('run', () => {
         key === 'meta/version.json' ? { mdi: '2.2.500', lucide: '2.2.500' } : null,
       ),
     } as unknown as R2Client;
-    const d1 = {
-      execute: vi.fn(async () => okResult),
-      batchAtomic: vi.fn(fakeBatchAtomic),
-    } as unknown as D1Client;
+    const d1 = { execute: makeExecute() } as unknown as D1Client;
     const collectSpy = vi.fn();
     const report = await run(baseConfig, {
       r2,
@@ -94,7 +95,6 @@ describe('run', () => {
           collectFromPath(fixturePath(`${collection}-mini.json`), '2.2.500'),
       },
     );
-    // schema apply may still run, but no INSERT INTO icons
     expect(executed.some((s) => s.startsWith('INSERT INTO icons '))).toBe(false);
     expect(executed.some((s) => s.startsWith('DELETE FROM icons'))).toBe(false);
   });
@@ -109,12 +109,11 @@ describe('run', () => {
       getJson: vi.fn(async () => null),
     } as unknown as R2Client;
     const d1 = {
-      execute: vi.fn(async () => okResult),
-      batchAtomic: vi.fn(async (stmts: readonly { sql: string }[]) => {
-        if (stmts.some((s) => s.sql.startsWith('INSERT INTO icons '))) {
+      execute: vi.fn(async (sql: string) => {
+        if (/^\s*INSERT INTO icons\b/i.test(sql) && !/icons_fts/.test(sql)) {
           throw new Error('boom');
         }
-        return stmts.map(() => okResult);
+        return okResult;
       }),
     } as unknown as D1Client;
     await expect(
@@ -145,7 +144,6 @@ describe('run', () => {
         }
         return okResult;
       }),
-      batchAtomic: vi.fn(fakeBatchAtomic),
     } as unknown as D1Client;
     await run(baseConfig, {
       r2,

--- a/tools/ingest/tests/seed-icons.test.ts
+++ b/tools/ingest/tests/seed-icons.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
-import type { D1Client } from '../src/d1.ts';
+import type { D1Client, D1Result } from '../src/d1.ts';
 import { seedIcons } from '../src/seed-icons.ts';
 import type { CollectionSnapshot } from '../src/types.ts';
-import { makeFakeBatchAtomic } from './_helpers.ts';
 
 const snap = (): CollectionSnapshot => ({
   collection: 'mdi',
@@ -28,44 +27,46 @@ const snap = (): CollectionSnapshot => ({
   } as CollectionSnapshot['body'],
 });
 
-const okResult = { success: true, meta: { changes: 0, last_row_id: null }, results: [] };
+const okResult: D1Result = { success: true, meta: { changes: 0, last_row_id: null }, results: [] };
 
-const fakeBatchAtomic = makeFakeBatchAtomic();
+const rowCountFromInsert = (sql: string): number => (sql.match(/\(/g)?.length ?? 0) - 1;
+
+const makeExecute = () =>
+  vi.fn(async (sql: string): Promise<D1Result> => {
+    if (/^\s*INSERT\b/i.test(sql)) {
+      return { ...okResult, meta: { changes: rowCountFromInsert(sql), last_row_id: null } };
+    }
+    return okResult;
+  });
 
 describe('seedIcons', () => {
-  test('deletes then inserts icons for each collection via a single atomic batch', async () => {
-    const batchAtomic = vi.fn(fakeBatchAtomic);
-    const execute = vi.fn(async () => okResult);
-    const client = { execute, batchAtomic } as unknown as D1Client;
+  test('DELETEs then INSERTs icons for each collection via serial execute calls', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
     const result = await seedIcons({ d1: client, snapshots: [snap()] });
     expect(result.deleted).toBe(1);
     expect(result.inserted).toBe(3);
-    expect(batchAtomic).toHaveBeenCalledTimes(1);
-    const statements = batchAtomic.mock.calls[0]?.[0] as ReadonlyArray<{ sql: string }>;
-    expect(statements[0]?.sql.startsWith('DELETE FROM icons')).toBe(true);
-    expect(statements.some((s) => s.sql.startsWith('INSERT INTO icons'))).toBe(true);
-    expect(execute).not.toHaveBeenCalled();
+    const calls = execute.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toMatch(/^DELETE FROM icons WHERE collection = 'mdi'/);
+    expect(calls.slice(1).every((s) => /^INSERT INTO icons/.test(s))).toBe(true);
   });
 
-  test('uses batchAtomic to combine DELETE and INSERT per collection', async () => {
-    const batchAtomic = vi.fn(async (stmts: unknown[]) =>
-      stmts.map(() => ({ success: true, meta: { changes: 1, last_row_id: null }, results: [] })),
-    );
-    const execute = vi.fn(async () => ({
-      success: true,
-      meta: { changes: 0, last_row_id: null },
-      results: [],
-    }));
-    const d1 = { execute, batchAtomic } as unknown as D1Client;
-    await seedIcons({ d1, snapshots: [snap()] });
-    expect(batchAtomic).toHaveBeenCalled();
-    const firstBatch = batchAtomic.mock.calls[0]?.[0] as ReadonlyArray<{ sql: string }>;
-    expect(firstBatch[0]?.sql).toContain('DELETE FROM icons');
+  test('inlines collection name as SQL literal in DELETE, escaping single quotes', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
+    const dangerous: CollectionSnapshot = {
+      ...snap(),
+      collection: "mdi's",
+      body: { prefix: 'x', icons: {} } as CollectionSnapshot['body'],
+    };
+    await seedIcons({ d1: client, snapshots: [dangerous] });
+    const firstSql = execute.mock.calls[0]?.[0];
+    expect(firstSql).toBe("DELETE FROM icons WHERE collection = 'mdi''s'");
   });
 
-  test('splits large collections into batches of batchSize rows within one statement array', async () => {
-    const batchAtomic = vi.fn(fakeBatchAtomic);
-    const client = { batchAtomic } as unknown as D1Client;
+  test('splits large collections into batches of batchSize rows per INSERT', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
     const icons: Record<string, { body: string }> = {};
     for (let i = 0; i < 1200; i++) icons[`i${i}`] = { body: '<path/>' };
     const big: CollectionSnapshot = {
@@ -78,54 +79,42 @@ describe('seedIcons', () => {
       body: { prefix: 'big', icons } as CollectionSnapshot['body'],
     };
     await seedIcons({ d1: client, snapshots: [big], batchSize: 500 });
-    const statements = batchAtomic.mock.calls[0]?.[0] as ReadonlyArray<{ sql: string }>;
-    const inserts = statements.filter((s) => s.sql.startsWith('INSERT INTO icons'));
-    // 1200 / 500 = 3 insert batches, plus the leading DELETE = 4 statements total
-    expect(inserts.length).toBe(3);
-    expect(statements.length).toBe(4);
+    const insertCalls = execute.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => /^INSERT INTO icons/.test(s));
+    // 1200 rows / 500 per batch = 3 INSERT statements
+    expect(insertCalls).toHaveLength(3);
+    expect(rowCountFromInsert(insertCalls[0] ?? '')).toBe(500);
+    expect(rowCountFromInsert(insertCalls[1] ?? '')).toBe(500);
+    expect(rowCountFromInsert(insertCalls[2] ?? '')).toBe(200);
   });
 
-  test('encodes categories and aliases as CSV strings, or null when absent', async () => {
-    const batchAtomic = vi.fn(fakeBatchAtomic);
-    const client = { batchAtomic } as unknown as D1Client;
+  test('encodes categories and aliases as CSV strings, NULL when absent', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
     await seedIcons({ d1: client, snapshots: [snap()] });
-    const statements = batchAtomic.mock.calls[0]?.[0] as ReadonlyArray<{
-      sql: string;
-      params: unknown[];
-    }>;
-    const insertParams = statements
-      .filter((s) => s.sql.startsWith('INSERT INTO icons'))
-      .flatMap((s) => s.params);
-    // parameter layout per row: collection, name, license, categories, tags, aliases, updated_at
-    const home = insertParams.slice(0, 7);
-    expect(home[0]).toBe('mdi');
-    expect(home[1]).toBe('home');
-    expect(home[3]).toBe('Navigation');
-    expect(home[5]).toBe('house');
-    const account = insertParams.slice(7, 14);
-    expect(account[3]).toBe('People');
-    expect(account[5]).toBeNull();
+    const insertSql =
+      execute.mock.calls.map((c) => c[0] as string).find((s) => /^INSERT INTO icons/.test(s)) ?? '';
+    // home row carries the alias 'house' and category 'Navigation'
+    expect(insertSql).toContain("'mdi', 'home', 'Apache-2.0', 'Navigation', NULL, 'house'");
+    // account row: category 'People', no aliases
+    expect(insertSql).toContain("'mdi', 'account', 'Apache-2.0', 'People', NULL, NULL");
+    // search row: no category, no alias
+    expect(insertSql).toContain("'mdi', 'search', 'Apache-2.0', NULL, NULL, NULL");
   });
 
-  test('default batchSize keeps bind params under 100 per statement', async () => {
-    const batchAtomic = vi.fn(fakeBatchAtomic);
-    const client = { batchAtomic } as unknown as D1Client;
-    const icons: Record<string, { body: string }> = {};
-    for (let i = 0; i < 50; i++) icons[`i${i}`] = { body: '<path/>' };
-    const snap: CollectionSnapshot = {
-      collection: 'test',
-      version: '1',
-      license: 'MIT',
-      total: 50,
-      defaultWidth: 24,
-      defaultHeight: 24,
-      body: { prefix: 'test', icons } as CollectionSnapshot['body'],
+  test('skips INSERT phase when a collection has zero icons', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
+    const empty: CollectionSnapshot = {
+      ...snap(),
+      body: { prefix: 'mdi', icons: {} } as CollectionSnapshot['body'],
     };
-    await seedIcons({ d1: client, snapshots: [snap] });
-    const statements = batchAtomic.mock.calls[0]?.[0] as ReadonlyArray<{
-      sql: string;
-      params: unknown[];
-    }>;
-    for (const s of statements) expect(s.params.length).toBeLessThanOrEqual(100);
+    const result = await seedIcons({ d1: client, snapshots: [empty] });
+    expect(result.deleted).toBe(1);
+    expect(result.inserted).toBe(0);
+    expect(execute).toHaveBeenCalledTimes(1);
+    const firstSql = (execute.mock.calls[0]?.[0] as string) ?? '';
+    expect(firstSql.startsWith('DELETE FROM icons')).toBe(true);
   });
 });

--- a/tools/ingest/tests/seed-synonyms.test.ts
+++ b/tools/ingest/tests/seed-synonyms.test.ts
@@ -1,69 +1,88 @@
 import type { SynonymDictionary } from '@icon-collection/synonyms';
 import { describe, expect, test, vi } from 'vitest';
-import type { D1Client } from '../src/d1.ts';
+import type { D1Client, D1Result } from '../src/d1.ts';
 import { seedSynonyms } from '../src/seed-synonyms.ts';
-import { makeFakeBatchAtomic } from './_helpers.ts';
 
-const fakeBatchAtomic = makeFakeBatchAtomic();
+const okResult: D1Result = { success: true, meta: { changes: 0, last_row_id: null }, results: [] };
+
+const rowCountFromInsert = (sql: string): number => (sql.match(/\(/g)?.length ?? 0) - 1;
+
+const makeExecute = () =>
+  vi.fn(async (sql: string): Promise<D1Result> => {
+    if (/^\s*INSERT\b/i.test(sql)) {
+      return { ...okResult, meta: { changes: rowCountFromInsert(sql), last_row_id: null } };
+    }
+    return okResult;
+  });
 
 describe('seedSynonyms', () => {
-  test('deletes all synonyms then inserts merged dictionaries via a single atomic batch', async () => {
-    const batchAtomic = vi.fn(fakeBatchAtomic);
-    const execute = vi.fn(async () => ({
-      success: true,
-      meta: { changes: 0, last_row_id: null },
-      results: [],
-    }));
-    const client = { execute, batchAtomic } as unknown as D1Client;
+  test('DELETEs all synonyms then INSERTs merged dictionaries via serial execute', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
     const dict: SynonymDictionary = [
       { term: 'home', expansion: 'house', lang: 'en' },
       { term: 'カート', expansion: 'cart', lang: 'ja' },
     ];
     const result = await seedSynonyms({ d1: client, dictionaries: [dict] });
     expect(result.inserted).toBe(2);
-    expect(batchAtomic).toHaveBeenCalledTimes(1);
-    const statements = batchAtomic.mock.calls[0]?.[0] as ReadonlyArray<{ sql: string }>;
-    expect(statements[0]?.sql).toBe('DELETE FROM synonyms');
-    expect(statements[1]?.sql.startsWith('INSERT INTO synonyms')).toBe(true);
-    expect(execute).not.toHaveBeenCalled();
+    const calls = execute.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toBe('DELETE FROM synonyms');
+    expect(calls[1]).toMatch(/^INSERT INTO synonyms/);
+  });
+
+  test('inlines term / expansion / lang / weight as SQL literals', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
+    const dict: SynonymDictionary = [{ term: 'home', expansion: 'house', lang: 'en', weight: 0.8 }];
+    await seedSynonyms({ d1: client, dictionaries: [dict] });
+    const insertSql =
+      execute.mock.calls.map((c) => c[0] as string).find((s) => /^INSERT INTO synonyms/.test(s)) ??
+      '';
+    expect(insertSql).toContain("('home', 'house', 'en', 0.8)");
+  });
+
+  test('defaults weight to 1 when not specified', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
+    const dict: SynonymDictionary = [{ term: 'a', expansion: 'b', lang: 'en' }];
+    await seedSynonyms({ d1: client, dictionaries: [dict] });
+    const insertSql =
+      execute.mock.calls.map((c) => c[0] as string).find((s) => /^INSERT INTO synonyms/.test(s)) ??
+      '';
+    expect(insertSql).toContain("('a', 'b', 'en', 1)");
   });
 
   test('uses default dictionaries when none provided (packages/synonyms)', async () => {
-    const batchAtomic = vi.fn(fakeBatchAtomic);
-    const client = { batchAtomic } as unknown as D1Client;
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
     const result = await seedSynonyms({ d1: client });
     expect(result.inserted).toBeGreaterThan(0);
   });
 
-  test('batches inserts by batchSize within one statement array', async () => {
-    const batchAtomic = vi.fn(fakeBatchAtomic);
-    const client = { batchAtomic } as unknown as D1Client;
+  test('splits large dictionaries into batches of batchSize rows per INSERT', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
     const dict: SynonymDictionary = Array.from({ length: 250 }, (_, i) => ({
       term: `t${i}`,
       expansion: `e${i}`,
       lang: 'en' as const,
     }));
     await seedSynonyms({ d1: client, dictionaries: [dict], batchSize: 100 });
-    const statements = batchAtomic.mock.calls[0]?.[0] as ReadonlyArray<{ sql: string }>;
-    const inserts = statements.filter((s) => s.sql.startsWith('INSERT INTO synonyms'));
-    // 250 / 100 = 3 insert batches (100 + 100 + 50), plus the leading DELETE = 4 statements
-    expect(inserts.length).toBe(3);
-    expect(statements.length).toBe(4);
+    const inserts = execute.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => /^INSERT INTO synonyms/.test(s));
+    expect(inserts).toHaveLength(3);
+    expect(rowCountFromInsert(inserts[0] ?? '')).toBe(100);
+    expect(rowCountFromInsert(inserts[1] ?? '')).toBe(100);
+    expect(rowCountFromInsert(inserts[2] ?? '')).toBe(50);
   });
 
-  test('default batchSize keeps bind params under 100 per statement', async () => {
-    const batchAtomic = vi.fn(fakeBatchAtomic);
-    const client = { batchAtomic } as unknown as D1Client;
-    const dict: SynonymDictionary = Array.from({ length: 50 }, (_, i) => ({
-      term: `t${i}`,
-      expansion: `e${i}`,
-      lang: 'en' as const,
-    }));
-    await seedSynonyms({ d1: client, dictionaries: [dict] });
-    const statements = batchAtomic.mock.calls[0]?.[0] as ReadonlyArray<{
-      sql: string;
-      params: unknown[];
-    }>;
-    for (const s of statements) expect(s.params.length).toBeLessThanOrEqual(100);
+  test('skips INSERT phase when no entries', async () => {
+    const execute = makeExecute();
+    const client = { execute } as unknown as D1Client;
+    const result = await seedSynonyms({ d1: client, dictionaries: [] });
+    expect(result.inserted).toBe(0);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[0]).toBe('DELETE FROM synonyms');
   });
 });


### PR DESCRIPTION
## Summary

PR #19 was merged at commit `b96f8c7` (dropping `remote: true` for CI), but two subsequent fixes on the same branch never made it into master:

- `87f1dd9` — fall back to serial execute in batchAtomic (D1 HTTP rejects params + multi-statement, code 7400)
- `c439db8` — bulk-insert via SQL literals instead of per-batch params (2000 rows per INSERT vs 10 rows, ~150x reduction in HTTP calls)

Confirmed via workflow run 31026839726 (dispatch on master post PR #19 merge): ingest still fails at `applySchema` follow-through because master's `batchAtomic` still sends `{sql: "s1; s2", params: [...]}` which D1 rejects.

## Fix

- `d1.ts` `execute` omits `params` from body when empty (enables multi-statement path with literals)
- `d1.ts` `batchAtomic` becomes serial execute (fallback for callers still using the API surface)
- `sql-literal.ts` new: `sqlLiteral(v)` serializes JS values as escaped SQL literals
- `seed-icons.ts` rewritten: DELETE (1 call) + N INSERTs with up to 2000 rows each (all values inlined as literals, no bind params)
- `seed-synonyms.ts` same treatment
- 53/53 unit tests pass with the new behavior asserted via SQL-string content matching

## Runtime impact estimate

Per-collection HTTP calls: `1 + ceil(icons / 2000)`. For MDI ~7500 icons: 5 calls (was 750+). 15 default collections: ~45 calls total. Full ingest should complete in minutes, not risk timeouts.

## Test plan
- [x] pnpm -F @icon-collection/ingest test — 53/53 pass
- [x] pnpm lint / typecheck — clean
- [ ] After merge: dispatch ingest workflow, verify D1 populates (SELECT COUNT(*) FROM icons > 0)
- [ ] After ingest: `/api/search?q=home` returns 200 with hits