### PR TITLE
fix(ingest): lower INSERT batch size to 500 rows (D1 statement size limit)

### DIFF
--- a/tools/ingest/src/seed-icons.ts
+++ b/tools/ingest/src/seed-icons.ts
@@ -2,10 +2,11 @@ import type { D1Client } from './d1.ts';
 import { sqlLiteral } from './sql-literal.ts';
 import type { CollectionSnapshot, IconifyJSON } from './types.ts';
 
-// Rows per INSERT statement. D1 HTTP has no hard bind-param ceiling here (we inline
-// values as SQL literals), so this is bounded only by request-body size. 2000 rows
-// at ~200 chars/row ≈ 400 KB per request — well under D1's 100 MB body limit.
-const DEFAULT_BATCH_SIZE = 2000;
+// Rows per INSERT statement. Bounded by D1's per-statement size limit
+// (SQLITE_LIMIT_SQL_LENGTH, roughly 100 KB). At ~100 chars/row this gives ~50 KB
+// per statement, leaving comfortable margin. Empirically 2000 rows already trips
+// "SQLITE_TOOBIG" for verbose collections like MDI.
+const DEFAULT_BATCH_SIZE = 500;
 
 type IconMeta = {
   categories: string | null;

--- a/tools/ingest/src/seed-synonyms.ts
+++ b/tools/ingest/src/seed-synonyms.ts
@@ -3,7 +3,7 @@ import type { D1Client } from './d1.ts';
 import { sqlLiteral } from './sql-literal.ts';
 
 // Rows per INSERT statement (see seed-icons.ts for rationale).
-const DEFAULT_BATCH_SIZE = 2000;
+const DEFAULT_BATCH_SIZE = 500;
 
 const buildInsertSql = (rows: readonly string[]): string =>
   `INSERT INTO synonyms (term, expansion, lang, weight) VALUES ${rows.join(', ')}`;


### PR DESCRIPTION
## Summary
Previous run hit \`code:7500 "statement too long: SQLITE_TOOBIG"\` on the first INSERT. D1 enforces SQLITE_LIMIT_SQL_LENGTH (~100 KB per statement); 2000 rows exceeded it on verbose collections like MDI.

Lower DEFAULT_BATCH_SIZE from 2000 → 500 in both seed-icons and seed-synonyms. At ~100 chars/row this gives ~50 KB per statement, comfortable margin under 100 KB.

## Impact
Per-collection HTTP calls become 1 + ceil(icons/500). MDI 7500 → 16 calls. 15 collections → ~250 calls total. Still very manageable (was going to be 750+ with 10-row batches before this whole refactor).

## Test plan
- [x] pnpm -F @icon-collection/ingest test — 53/53 pass
- [x] pnpm lint / typecheck — clean
- [ ] After merge: dispatch ingest, verify no more SQLITE_TOOBIG