### PR TITLE
fix(web): bind existing SESSION KV namespace

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -15,6 +15,16 @@
       "bucket_name": "icon-collection"
     }
   ],
+  // Astro Cloudflare adapter auto-injects a SESSION KV binding for its experimental
+  // sessions feature. We do not use sessions, but the adapter still requires the
+  // binding; explicitly point at the existing namespace so wrangler binds instead
+  // of trying to recreate it on every deploy (KV code 10014 conflict).
+  "kv_namespaces": [
+    {
+      "binding": "SESSION",
+      "id": "647c22408a344094b51bd6cf055deeab"
+    }
+  ],
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,


### PR DESCRIPTION
## Root cause
Astro Cloudflare adapter auto-injects a \`SESSION\` KV binding for its experimental sessions feature. On every \`wrangler deploy\`, the CLI tries to CREATE the namespace \`icon-collection-web-session\`, which succeeded once but now returns \`code:10014 "a namespace with this account ID and title already exists"\` — blocking all subsequent deploys.

## Fix
Explicitly bind the existing namespace in \`apps/web/wrangler.jsonc\` so wrangler treats it as pre-provisioned:

\`\`\`jsonc
"kv_namespaces": [
  { "binding": "SESSION", "id": "647c22408a344094b51bd6cf055deeab" }
]
\`\`\`

## Impact
Unblocks Cloudflare Workers Builds. Once deploy succeeds, production Worker gets the Astro server endpoints (\`/api/search\`, \`/icon/*.svg\`, \`/icon/*.mx\`) and the D1 data ingested via PR #21 becomes reachable via HTTP.

## Test plan
- [x] pnpm lint / typecheck / test — clean
- [ ] After merge: Cloudflare Workers Build should succeed
- [ ] After deploy: curl icon-collection-web.kage1020.workers.dev/api/search?q=home returns 200 with hits