### PR TITLE
feat(web): polish search UI and fix invisible SVG icons

### DIFF
--- a/apps/web/src/islands/SearchPage.tsx
+++ b/apps/web/src/islands/SearchPage.tsx
@@ -4,6 +4,7 @@ import type { FilterValue, Host } from '@icon-collection/ui';
 import {
   CopyMenu,
   createSvgCache,
+  EmptyState,
   FilterBar,
   HostProvider,
   IconGrid,
@@ -47,6 +48,92 @@ const COLLECTION_OPTIONS = [
 
 const LICENSE_OPTIONS = ['Apache-2.0', 'MIT', 'ISC', 'CC-BY-4.0'] as const;
 
+const formatCount = (n: number): string => n.toLocaleString('en-US');
+
+type ResultBodyProps = {
+  status: ReturnType<typeof useSearch>['status'];
+  hits: readonly IconHit[];
+  hasQuery: boolean;
+  selectedKey: string | null;
+  onSelect: (hit: IconHit) => void;
+  errorMessage: string | undefined;
+};
+
+const ResultBody = ({
+  status,
+  hits,
+  hasQuery,
+  selectedKey,
+  onSelect,
+  errorMessage,
+}: ResultBodyProps) => {
+  if (status === 'error') {
+    return (
+      <div class="flex flex-col gap-2">
+        <EmptyState variant="error" />
+        {errorMessage ? (
+          <p class="text-center text-xs text-red-600 dark:text-red-400">{errorMessage}</p>
+        ) : null}
+      </div>
+    );
+  }
+  if (!hasQuery) return <EmptyState variant="idle" />;
+  if (status === 'success' && hits.length === 0) return <EmptyState variant="empty" />;
+  return <IconGrid hits={hits} onSelect={onSelect} {...(selectedKey ? { selectedKey } : {})} />;
+};
+
+const SelectedDetail = ({ hit, onClose }: { hit: IconHit; onClose: () => void }) => (
+  <aside class="sticky top-6 flex flex-col gap-4 rounded-2xl border border-neutral-200 bg-white/80 p-5 shadow-lg backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/70">
+    <div class="flex items-start justify-between gap-2">
+      <div class="flex flex-col">
+        <span class="text-[11px] font-semibold uppercase tracking-wider text-sky-600 dark:text-sky-400">
+          {hit.collection}
+        </span>
+        <h2 class="text-lg font-semibold text-neutral-900 dark:text-neutral-100">{hit.name}</h2>
+        <span class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+          {hit.license} · {hit.width}×{hit.height}
+        </span>
+      </div>
+      <button
+        type="button"
+        aria-label="Close details"
+        onClick={onClose}
+        class="rounded-full p-1.5 text-neutral-400 transition hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M18 6 6 18"></path>
+          <path d="m6 6 12 12"></path>
+        </svg>
+      </button>
+    </div>
+    <div class="flex aspect-square items-center justify-center overflow-hidden rounded-xl border border-dashed border-neutral-200 bg-neutral-50 [font-size:6rem] text-neutral-800 dark:border-neutral-700 dark:bg-neutral-950/60 dark:text-neutral-100">
+      <img
+        src={`/icon/${hit.collection}/${hit.name}.svg`}
+        alt=""
+        class="h-24 w-24 [color-scheme:normal]"
+        loading="lazy"
+      />
+    </div>
+    <div class="flex flex-col gap-2">
+      <span class="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+        Copy
+      </span>
+      <CopyMenu hit={hit} />
+    </div>
+  </aside>
+);
+
 const SearchInner = () => {
   const [q, setQ] = useState('');
   const [filter, setFilter] = useState<FilterValue>({ collection: [], license: [] });
@@ -60,43 +147,81 @@ const SearchInner = () => {
       }
     : null;
   const state = useSearch(query);
+  const hits = state.data?.hits ?? [];
+  const total = state.data?.total ?? 0;
+  const selectedKey = selectedHit ? `${selectedHit.collection}/${selectedHit.name}` : null;
 
-  // 検索条件が変わると同じ選択が別の結果を指す可能性があるため、選択状態をクリアする。
   useEffect(() => {
     setSelectedHit(null);
   }, [q, filter]);
 
+  const errorMessage = state.status === 'error' && state.error ? state.error.message : undefined;
+
   return (
-    <div class="flex flex-col gap-4">
-      <SearchBox initialValue={q} onChange={setQ} placeholder="Search icons…" />
-      <FilterBar
-        collections={COLLECTION_OPTIONS}
-        licenses={LICENSE_OPTIONS}
-        value={filter}
-        onChange={setFilter}
-      />
-      {state.status === 'error' ? (
-        <p class="text-red-600">Error: {state.error?.message}</p>
-      ) : (
-        <IconGrid hits={state.data?.hits ?? []} onSelect={setSelectedHit} />
-      )}
-      {selectedHit ? (
-        <div class="flex flex-col gap-2 rounded border border-neutral-200 p-3">
-          <div class="flex items-center justify-between">
-            <span class="text-sm font-medium">
-              {selectedHit.collection}/{selectedHit.name}
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-3">
+        <SearchBox
+          initialValue={q}
+          onChange={setQ}
+          placeholder="Search 55,000+ icons — try 'home', 'arrow', or 'ホーム'"
+        />
+        <FilterBar
+          collections={COLLECTION_OPTIONS}
+          licenses={LICENSE_OPTIONS}
+          value={filter}
+          onChange={setFilter}
+        />
+      </div>
+
+      <div class="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <section class="flex flex-col gap-3">
+          <div class="flex items-center justify-between text-xs text-neutral-500 dark:text-neutral-400">
+            <span aria-live="polite">
+              {state.status === 'loading' && q.trim()
+                ? 'Searching…'
+                : q.trim() && state.status === 'success'
+                  ? `${formatCount(total)} matches`
+                  : 'Type to search'}
             </span>
-            <button
-              type="button"
-              class="rounded border border-neutral-300 px-2 py-1 text-xs hover:border-neutral-500"
-              onClick={() => setSelectedHit(null)}
-            >
-              Close
-            </button>
           </div>
-          <CopyMenu hit={selectedHit} />
+          <ResultBody
+            status={state.status}
+            hits={hits}
+            hasQuery={q.trim().length > 0}
+            selectedKey={selectedKey}
+            onSelect={setSelectedHit}
+            errorMessage={errorMessage}
+          />
+        </section>
+
+        <div class="lg:min-h-[400px]">
+          {selectedHit ? (
+            <SelectedDetail hit={selectedHit} onClose={() => setSelectedHit(null)} />
+          ) : (
+            <div class="sticky top-6 hidden flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-neutral-300 bg-white/50 p-8 text-center text-xs text-neutral-500 lg:flex dark:border-neutral-700 dark:bg-neutral-900/40 dark:text-neutral-400">
+              <div class="flex h-12 w-12 items-center justify-center rounded-full bg-neutral-100 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M9 11l3 3L22 4"></path>
+                  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+                </svg>
+              </div>
+              <p class="text-sm font-medium text-neutral-700 dark:text-neutral-200">Pick an icon</p>
+              <p>Click a result to preview and copy.</p>
+            </div>
+          )}
         </div>
-      ) : null}
+      </div>
     </div>
   );
 };

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -24,7 +24,6 @@ const { title, description } = Astro.props;
     </script>
   </head>
   <body class="min-h-dvh bg-neutral-50 text-neutral-900 antialiased dark:bg-neutral-950 dark:text-neutral-100">
-    <div class="pointer-events-none fixed inset-x-0 top-0 -z-10 h-[420px] bg-gradient-to-b from-sky-100/70 via-transparent to-transparent dark:from-sky-500/10"></div>
     <slot />
   </body>
 </html>

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -2,17 +2,29 @@
 import '../styles/global.css';
 export interface Props {
   title: string;
+  description?: string;
 }
-const { title } = Astro.props;
+const { title, description } = Astro.props;
 ---
 <!doctype html>
-<html lang="ja">
+<html lang="ja" class="scroll-smooth">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    {description ? <meta name="description" content={description} /> : null}
     <title>{title}</title>
+    <script is:inline>
+      (() => {
+        const stored = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const resolved = stored ?? (prefersDark ? 'dark' : 'light');
+        if (resolved === 'dark') document.documentElement.classList.add('dark');
+      })();
+    </script>
   </head>
-  <body class="min-h-dvh bg-neutral-50 text-neutral-900">
+  <body class="min-h-dvh bg-neutral-50 text-neutral-900 antialiased dark:bg-neutral-950 dark:text-neutral-100">
+    <div class="pointer-events-none fixed inset-x-0 top-0 -z-10 h-[420px] bg-gradient-to-b from-sky-100/70 via-transparent to-transparent dark:from-sky-500/10"></div>
     <slot />
   </body>
 </html>

--- a/apps/web/src/pages/icon/[collection]/[name].svg.ts
+++ b/apps/web/src/pages/icon/[collection]/[name].svg.ts
@@ -35,7 +35,12 @@ export const GET: APIRoute = async ({ request, params }) => {
 
   const width = icon.width ?? json.width ?? 24;
   const height = icon.height ?? json.height ?? 24;
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">${icon.body}</svg>`;
+  // `width="1em"` / `height="1em"` gives a sensible intrinsic size when the SVG
+  // is embedded via `<img>` or referenced without an explicit CSS size — the
+  // icon scales with the surrounding `font-size`. Inline consumers can still
+  // override via CSS (e.g. `[&_svg]:h-full`) because inline styles beat
+  // presentational attributes at layout time.
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 ${width} ${height}">${icon.body}</svg>`;
   const etag = `"sha256:${await hashSha256(svg)}"`;
   const res = new Response(svg, {
     headers: {

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -9,7 +9,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <header class="sticky top-0 z-20 border-b border-neutral-200/60 bg-white/70 backdrop-blur-md dark:border-neutral-800/60 dark:bg-neutral-950/60">
     <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3">
       <a href="/" class="group inline-flex items-center gap-2">
-        <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-indigo-500 text-white shadow-sm ring-1 ring-white/40 dark:ring-white/10" aria-hidden>
+        <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-neutral-900 text-white shadow-sm dark:bg-neutral-100 dark:text-neutral-900" aria-hidden="true">
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M12 2 4 6v6c0 5 3.5 9.4 8 10 4.5-.6 8-5 8-10V6z"></path>
             <path d="m9 12 2 2 4-4"></path>
@@ -38,8 +38,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         55,811 icons indexed
       </span>
       <h1 class="text-3xl font-bold tracking-tight text-neutral-900 sm:text-4xl dark:text-neutral-100">
-        Find the icon,
-        <span class="bg-gradient-to-r from-sky-500 to-indigo-500 bg-clip-text text-transparent">copy it in one click.</span>
+        Find the icon, copy it in one click.
       </h1>
       <p class="max-w-2xl text-sm text-neutral-600 sm:text-base dark:text-neutral-400">
         Unified full-text search over MDI, Lucide, Heroicons, Tabler and more. Powered by SQLite FTS5 on Cloudflare D1, delivered from the edge.

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -2,9 +2,55 @@
 import { SearchPage } from '../islands/SearchPage.tsx';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<BaseLayout title="IconCollection">
-  <main class="mx-auto flex max-w-6xl flex-col gap-6 p-6">
-    <h1 class="text-2xl font-semibold">IconCollection</h1>
+<BaseLayout
+  title="IconCollection — 55,000+ open-source icons, searchable"
+  description="Search across MDI, Lucide, Heroicons, Tabler and more. Copy SVG / JSX / mxGraph diagram assets in one click."
+>
+  <header class="sticky top-0 z-20 border-b border-neutral-200/60 bg-white/70 backdrop-blur-md dark:border-neutral-800/60 dark:bg-neutral-950/60">
+    <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3">
+      <a href="/" class="group inline-flex items-center gap-2">
+        <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-indigo-500 text-white shadow-sm ring-1 ring-white/40 dark:ring-white/10" aria-hidden>
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 2 4 6v6c0 5 3.5 9.4 8 10 4.5-.6 8-5 8-10V6z"></path>
+            <path d="m9 12 2 2 4-4"></path>
+          </svg>
+        </span>
+        <span class="flex flex-col leading-tight">
+          <span class="text-sm font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">IconCollection</span>
+          <span class="text-[10px] uppercase tracking-widest text-neutral-500 dark:text-neutral-400">Unified icon search</span>
+        </span>
+      </a>
+      <nav class="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+        <a href="https://github.com/kage1020/IconCollection" class="inline-flex items-center gap-1.5 rounded-lg border border-neutral-200 bg-white px-2.5 py-1.5 font-medium text-neutral-700 shadow-sm transition hover:border-neutral-300 hover:text-neutral-900 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-700 dark:hover:text-neutral-100" rel="noopener noreferrer" target="_blank">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.1 3.29 9.42 7.87 10.95.58.1.79-.25.79-.56v-2.14c-3.2.7-3.87-1.37-3.87-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.75 1.18 1.75 1.18 1.02 1.75 2.68 1.24 3.34.95.1-.74.4-1.24.72-1.52-2.55-.29-5.24-1.28-5.24-5.68 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.17 1.18a11.02 11.02 0 0 1 5.77 0c2.2-1.49 3.17-1.18 3.17-1.18.62 1.59.23 2.76.11 3.05.74.8 1.18 1.83 1.18 3.08 0 4.41-2.69 5.39-5.25 5.67.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5z"></path>
+          </svg>
+          GitHub
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="mx-auto flex max-w-6xl flex-col gap-8 px-6 py-10">
+    <section class="flex flex-col items-start gap-4">
+      <span class="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-wider text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-300">
+        <span class="h-1.5 w-1.5 rounded-full bg-sky-500"></span>
+        55,811 icons indexed
+      </span>
+      <h1 class="text-3xl font-bold tracking-tight text-neutral-900 sm:text-4xl dark:text-neutral-100">
+        Find the icon,
+        <span class="bg-gradient-to-r from-sky-500 to-indigo-500 bg-clip-text text-transparent">copy it in one click.</span>
+      </h1>
+      <p class="max-w-2xl text-sm text-neutral-600 sm:text-base dark:text-neutral-400">
+        Unified full-text search over MDI, Lucide, Heroicons, Tabler and more. Powered by SQLite FTS5 on Cloudflare D1, delivered from the edge.
+      </p>
+    </section>
+
     <SearchPage client:load apiBaseUrl="" />
+
+    <footer class="mt-8 flex flex-col items-center gap-1 border-t border-neutral-200 pt-6 text-xs text-neutral-500 dark:border-neutral-800 dark:text-neutral-400">
+      <span>Icons are property of their respective authors — licences shown per collection.</span>
+      <span>Built with Astro · Preact · Cloudflare Workers · D1</span>
+    </footer>
   </main>
 </BaseLayout>

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,2 +1,11 @@
 @import "tailwindcss";
 @import "@icon-collection/ui/styles.css";
+
+/*
+ * pnpm resolves `@icon-collection/ui` as a symlinked node_modules entry,
+ * which Tailwind v4's auto-detection skips. Redeclare the source paths
+ * from the consumer so the JIT emits every class referenced inside the
+ * shared UI package, independent of whether `@source` propagates through
+ * `@import`ed CSS in the current Tailwind version.
+ */
+@source "../../../../packages/ui/src/**/*.{ts,tsx}";

--- a/apps/web/tests/icon-svg.test.ts
+++ b/apps/web/tests/icon-svg.test.ts
@@ -32,6 +32,8 @@ describe('GET /icon/{collection}/{name}.svg', () => {
     const body = await res.text();
     expect(body).toContain('viewBox="0 0 24 24"');
     expect(body).toContain('xmlns="http://www.w3.org/2000/svg"');
+    expect(body).toContain('width="1em"');
+    expect(body).toContain('height="1em"');
     expect(body).toContain('<path d="M0 0h24v24H0z"/>');
   });
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -39,12 +39,12 @@ export const createApiClient = (config: ApiClientConfig): ApiClient => {
     search: async (query) => {
       const url = buildUrl(config.baseUrl, 'api/search');
       url.searchParams.set('q', query.q);
-      if (query.collection?.length) {
-        url.searchParams.set('collection', query.collection.join(','));
-      }
-      if (query.license?.length) {
-        url.searchParams.set('license', query.license.join(','));
-      }
+      // Repeat the parameter once per value (`?collection=a&collection=b`)
+      // so the server's `getAll('collection')` sees each collection as a
+      // separate string. Comma-joining would push `"a,b"` as a single
+      // literal into the SQL `IN (...)` list and match zero rows.
+      for (const c of query.collection ?? []) url.searchParams.append('collection', c);
+      for (const l of query.license ?? []) url.searchParams.append('license', l);
       if (typeof query.limit === 'number') {
         url.searchParams.set('limit', String(query.limit));
       }

--- a/packages/core/tests/api.test.ts
+++ b/packages/core/tests/api.test.ts
@@ -31,8 +31,8 @@ describe('search', () => {
     const url = fetchFn.mock.calls[0]?.[0] as URL;
     expect(url.pathname).toBe('/api/search');
     expect(url.searchParams.get('q')).toBe('home');
-    expect(url.searchParams.get('collection')).toBe('mdi,lucide');
-    expect(url.searchParams.get('license')).toBe('MIT');
+    expect(url.searchParams.getAll('collection')).toEqual(['mdi', 'lucide']);
+    expect(url.searchParams.getAll('license')).toEqual(['MIT']);
     expect(url.searchParams.get('limit')).toBe('30');
   });
 

--- a/packages/ui/src/CopyMenu.tsx
+++ b/packages/ui/src/CopyMenu.tsx
@@ -5,16 +5,64 @@ export type CopyMenuProps = { hit: IconHit };
 
 export const CopyMenu = ({ hit }: CopyMenuProps) => {
   const copy = useCopy();
-  const button = 'rounded border border-neutral-300 px-2 py-1 text-xs hover:border-neutral-500';
+  const button =
+    'inline-flex items-center gap-1.5 rounded-lg border border-neutral-200 bg-white px-3 py-1.5 text-xs font-medium text-neutral-700 shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300 hover:text-sky-700 hover:shadow-md active:translate-y-0 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-sky-500 dark:hover:text-sky-400';
   return (
-    <div class="flex gap-1">
+    <div class="flex flex-wrap gap-2">
       <button type="button" class={button} onClick={() => copy('svg', hit)}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
+        </svg>
         SVG
       </button>
       <button type="button" class={button} onClick={() => copy('jsx', hit)}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="16 18 22 12 16 6"></polyline>
+          <polyline points="8 6 2 12 8 18"></polyline>
+        </svg>
         JSX
       </button>
       <button type="button" class={button} onClick={() => copy('mx', hit)}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <rect width="8" height="8" x="3" y="3" rx="1"></rect>
+          <rect width="8" height="8" x="13" y="13" rx="1"></rect>
+          <path d="M11 7h2"></path>
+          <path d="M7 11v2"></path>
+        </svg>
         Diagram
       </button>
     </div>

--- a/packages/ui/src/EmptyState.tsx
+++ b/packages/ui/src/EmptyState.tsx
@@ -1,16 +1,65 @@
-export type EmptyStateProps = { variant: 'empty' | 'error' };
+export type EmptyStateProps = { variant: 'empty' | 'error' | 'idle' };
+
+const SearchIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="32"
+    height="32"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="7"></circle>
+    <path d="m20 20-3-3"></path>
+  </svg>
+);
+
+const AlertIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="32"
+    height="32"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 9v4"></path>
+    <path d="M12 17h.01"></path>
+    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+  </svg>
+);
 
 export const EmptyState = ({ variant }: EmptyStateProps) => (
-  <div class="flex h-full flex-col items-center justify-center gap-1 py-8 text-neutral-500">
+  <div class="flex flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-neutral-300 bg-white/50 py-16 text-center text-neutral-500 dark:border-neutral-700 dark:bg-neutral-900/40 dark:text-neutral-400">
+    <div class="mb-1 flex h-14 w-14 items-center justify-center rounded-full bg-neutral-100 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+      {variant === 'error' ? <AlertIcon /> : <SearchIcon />}
+    </div>
     {variant === 'empty' ? (
       <>
-        <p class="text-sm">No icons matched.</p>
+        <p class="text-sm font-medium text-neutral-700 dark:text-neutral-200">No icons matched.</p>
         <p class="text-xs">Try a different keyword.</p>
+      </>
+    ) : variant === 'error' ? (
+      <>
+        <p class="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+          Something went wrong.
+        </p>
+        <p class="text-xs">Please retry in a moment.</p>
       </>
     ) : (
       <>
-        <p class="text-sm">Something went wrong.</p>
-        <p class="text-xs">Please retry in a moment.</p>
+        <p class="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+          Search across 55,000+ icons.
+        </p>
+        <p class="text-xs">MDI, Lucide, Heroicons, Tabler and more.</p>
       </>
     )}
   </div>

--- a/packages/ui/src/FilterBar.tsx
+++ b/packages/ui/src/FilterBar.tsx
@@ -15,40 +15,88 @@ export type FilterBarProps = {
 const toggle = (arr: readonly string[], name: string): string[] =>
   arr.includes(name) ? arr.filter((v) => v !== name) : [...arr, name];
 
-export const FilterBar = ({ collections, licenses, value, onChange }: FilterBarProps) => (
-  <div class="flex flex-wrap items-center gap-3 text-xs">
-    <fieldset class="flex flex-wrap items-center gap-2">
-      <legend class="mr-1 font-semibold">Collection</legend>
-      {collections.map((c) => (
-        <label key={c.name} class="inline-flex items-center gap-1">
-          <input
-            type="checkbox"
-            checked={value.collection.includes(c.name)}
-            onChange={() => onChange({ ...value, collection: toggle(value.collection, c.name) })}
-          />
-          <span>{c.label}</span>
-        </label>
-      ))}
-    </fieldset>
-    <fieldset class="flex flex-wrap items-center gap-2">
-      <legend class="mr-1 font-semibold">License</legend>
-      {licenses.map((l) => (
-        <label key={l} class="inline-flex items-center gap-1">
-          <input
-            type="checkbox"
-            checked={value.license.includes(l)}
-            onChange={() => onChange({ ...value, license: toggle(value.license, l) })}
-          />
-          <span>{l}</span>
-        </label>
-      ))}
-    </fieldset>
-    <button
-      type="button"
-      class="ml-auto rounded border border-neutral-300 px-2 py-1"
-      onClick={() => onChange({ collection: [], license: [] })}
-    >
-      Clear
-    </button>
-  </div>
-);
+// Pill-shaped chip: the real <input> stays in the accessibility tree (visually
+// hidden but still keyboard-reachable) and the sibling <span> paints the chip.
+// peer-checked + peer-focus-visible drive the visual state so we keep the
+// native semantics rather than mimicking them with role="button".
+const chipInput = 'peer sr-only';
+const chipLabel =
+  'inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-3 py-1 text-xs font-medium text-neutral-600 shadow-sm transition hover:border-neutral-300 hover:text-neutral-900 peer-checked:border-sky-500 peer-checked:bg-sky-500 peer-checked:text-white peer-focus-visible:ring-2 peer-focus-visible:ring-sky-300 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-neutral-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:border-neutral-700 dark:hover:text-neutral-100 dark:peer-focus-visible:ring-offset-neutral-950';
+
+export const FilterBar = ({ collections, licenses, value, onChange }: FilterBarProps) => {
+  const activeCount = value.collection.length + value.license.length;
+  return (
+    <div class="flex flex-col gap-3 rounded-2xl border border-neutral-200 bg-white/70 p-4 shadow-sm backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/60">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M3 6h18"></path>
+            <path d="M7 12h10"></path>
+            <path d="M10 18h4"></path>
+          </svg>
+          <span>Filters</span>
+          {activeCount > 0 ? (
+            <span class="rounded-full bg-sky-500 px-1.5 py-0.5 text-[10px] font-semibold text-white">
+              {activeCount}
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          class="rounded-full border border-transparent px-2 py-1 text-xs text-neutral-500 transition hover:border-neutral-200 hover:text-neutral-900 dark:hover:border-neutral-700 dark:hover:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={() => onChange({ collection: [], license: [] })}
+          disabled={activeCount === 0}
+        >
+          Clear
+        </button>
+      </div>
+
+      <fieldset class="flex flex-wrap items-center gap-2">
+        <legend class="mb-1.5 mr-2 text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+          Collection
+        </legend>
+        {collections.map((c) => (
+          <label key={c.name} class="inline-flex">
+            <input
+              type="checkbox"
+              class={chipInput}
+              checked={value.collection.includes(c.name)}
+              onChange={() => onChange({ ...value, collection: toggle(value.collection, c.name) })}
+              aria-label={c.label}
+            />
+            <span class={chipLabel}>{c.label}</span>
+          </label>
+        ))}
+      </fieldset>
+
+      <fieldset class="flex flex-wrap items-center gap-2">
+        <legend class="mb-1.5 mr-2 text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+          License
+        </legend>
+        {licenses.map((l) => (
+          <label key={l} class="inline-flex">
+            <input
+              type="checkbox"
+              class={chipInput}
+              checked={value.license.includes(l)}
+              onChange={() => onChange({ ...value, license: toggle(value.license, l) })}
+              aria-label={l}
+            />
+            <span class={chipLabel}>{l}</span>
+          </label>
+        ))}
+      </fieldset>
+    </div>
+  );
+};

--- a/packages/ui/src/IconCell.tsx
+++ b/packages/ui/src/IconCell.tsx
@@ -9,13 +9,14 @@ const sanitizeSvg = (body: string): string =>
 export type IconCellProps = {
   hit: IconHit;
   onSelect?: (hit: IconHit) => void;
+  selected?: boolean;
 };
 
 type CellStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 const cacheKey = (h: IconHit) => `${h.collection}/${h.name}`;
 
-export const IconCell = ({ hit, onSelect }: IconCellProps) => {
+export const IconCell = ({ hit, onSelect, selected = false }: IconCellProps) => {
   const host = useHost();
   const client = host.apiClient;
   const [status, setStatus] = useState<CellStatus>(() =>
@@ -51,27 +52,41 @@ export const IconCell = ({ hit, onSelect }: IconCellProps) => {
     return () => observer.disconnect();
   }, [status, client, hit.collection, hit.name]);
 
+  const base =
+    'group relative flex aspect-square flex-col items-center justify-center gap-1 rounded-xl border bg-white p-2 text-neutral-700 shadow-sm transition-all duration-150 hover:-translate-y-0.5 hover:border-sky-300 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-50 dark:bg-neutral-900 dark:text-neutral-200 dark:focus-visible:ring-offset-neutral-950';
+  const state = selected
+    ? 'border-sky-500 ring-2 ring-sky-400 ring-offset-2 ring-offset-neutral-50 dark:ring-offset-neutral-950'
+    : 'border-neutral-200 dark:border-neutral-800';
+
   return (
     <button
       ref={containerRef}
       type="button"
-      class="flex aspect-square flex-col items-center justify-center rounded border border-neutral-200 p-2 hover:border-neutral-400"
+      class={`${base} ${state}`}
       aria-label={`${hit.collection}/${hit.name}`}
+      aria-pressed={selected}
       onClick={() => onSelect?.(hit)}
     >
-      {status === 'ready' && svg ? (
-        <span
-          class="h-8 w-8 [&_svg]:h-full [&_svg]:w-full"
-          dangerouslySetInnerHTML={{ __html: svg }}
-        />
-      ) : status === 'error' ? (
-        <span role="img" aria-label="failed" class="text-neutral-400">
-          ?
-        </span>
-      ) : (
-        <span aria-busy class="h-8 w-8 animate-pulse rounded bg-neutral-100" />
-      )}
-      <span class="mt-1 truncate text-[10px] text-neutral-500">{hit.name}</span>
+      <span class="flex flex-1 items-center justify-center [font-size:2rem] leading-none">
+        {status === 'ready' && svg ? (
+          <span
+            class="block h-8 w-8 text-neutral-800 transition-colors group-hover:text-sky-600 dark:text-neutral-100 dark:group-hover:text-sky-400 [&_svg]:h-full [&_svg]:w-full"
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        ) : status === 'error' ? (
+          <span role="img" aria-label="failed" class="text-neutral-400">
+            ?
+          </span>
+        ) : (
+          <span
+            aria-busy
+            class="h-8 w-8 animate-pulse rounded bg-neutral-100 dark:bg-neutral-800"
+          />
+        )}
+      </span>
+      <span class="w-full truncate text-center text-[10px] text-neutral-500 dark:text-neutral-400">
+        {hit.name}
+      </span>
     </button>
   );
 };

--- a/packages/ui/src/IconGrid.tsx
+++ b/packages/ui/src/IconGrid.tsx
@@ -6,26 +6,40 @@ export type IconGridProps = {
   columns?: number;
   cellSize?: number;
   onSelect?: (hit: IconHit) => void;
+  selectedKey?: string;
 };
 
-// virtua の VGrid による仮想スクロールは Web ビルドで有効化する予定。
-// テスト環境（happy-dom）では layout 情報が乏しく仮想化が機能しないため、
-// 非仮想の CSS grid を既定とする。
-export const IconGrid = ({ hits, columns = 6, cellSize = 64, onSelect }: IconGridProps) => {
+// Virtualisation via virtua's VGrid is planned for the web build. In the test
+// environment (happy-dom) layout metrics are unreliable and virtualisation
+// misbehaves, so we default to a non-virtualised CSS grid.
+//
+// When callers pass an explicit `columns`, we honour it (this preserves the
+// unit-test contract). Without one, we let the grid reflow responsively based
+// on `cellSize` — icon walls look better wide than in a fixed 6-column strip.
+export const IconGrid = ({
+  hits,
+  columns,
+  cellSize = 88,
+  onSelect,
+  selectedKey,
+}: IconGridProps) => {
+  const style =
+    typeof columns === 'number'
+      ? { gridTemplateColumns: `repeat(${columns}, minmax(0, ${cellSize}px))` }
+      : { gridTemplateColumns: `repeat(auto-fill, minmax(${cellSize}px, 1fr))` };
   return (
-    <div
-      class="grid gap-2"
-      style={{
-        gridTemplateColumns: `repeat(${columns}, minmax(0, ${cellSize}px))`,
-      }}
-    >
-      {hits.map((hit) => (
-        <IconCell
-          key={`${hit.collection}/${hit.name}`}
-          hit={hit}
-          {...(onSelect ? { onSelect } : {})}
-        />
-      ))}
+    <div class="grid gap-2 sm:gap-3" style={style}>
+      {hits.map((hit) => {
+        const key = `${hit.collection}/${hit.name}`;
+        return (
+          <IconCell
+            key={key}
+            hit={hit}
+            selected={selectedKey === key}
+            {...(onSelect ? { onSelect } : {})}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/packages/ui/src/SearchBox.tsx
+++ b/packages/ui/src/SearchBox.tsx
@@ -29,27 +29,79 @@ export const SearchBox = ({
     timerRef.current = setTimeout(() => onChange(next), debounceMs);
   };
 
+  const clear = () => {
+    setValue('');
+    if (timerRef.current) clearTimeout(timerRef.current);
+    onChange('');
+  };
+
   return (
-    <input
-      type="search"
-      class="w-full rounded border border-neutral-300 px-3 py-2 text-sm outline-none focus:border-neutral-500"
-      value={value}
-      placeholder={placeholder}
-      onInput={(e) => {
-        const next = (e.currentTarget as HTMLInputElement).value;
-        setValue(next);
-        scheduleChange(next);
-      }}
-      onCompositionStart={() => {
-        composingRef.current = true;
-        if (timerRef.current) clearTimeout(timerRef.current);
-      }}
-      onCompositionEnd={(e) => {
-        composingRef.current = false;
-        const next = (e.currentTarget as HTMLInputElement).value;
-        setValue(next);
-        scheduleChange(next);
-      }}
-    />
+    <div class="group relative">
+      <span
+        aria-hidden
+        class="pointer-events-none absolute inset-y-0 left-4 flex items-center text-neutral-400 group-focus-within:text-sky-500 dark:text-neutral-500"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="7"></circle>
+          <path d="m20 20-3-3"></path>
+        </svg>
+      </span>
+      <input
+        type="search"
+        class="block w-full rounded-2xl border border-neutral-200 bg-white/80 py-3.5 pl-12 pr-12 text-base shadow-sm outline-none backdrop-blur transition placeholder:text-neutral-400 focus:border-sky-400 focus:ring-4 focus:ring-sky-100 dark:border-neutral-800 dark:bg-neutral-900/70 dark:placeholder:text-neutral-500 dark:focus:border-sky-500 dark:focus:ring-sky-500/20"
+        value={value}
+        placeholder={placeholder}
+        onInput={(e) => {
+          const next = (e.currentTarget as HTMLInputElement).value;
+          setValue(next);
+          scheduleChange(next);
+        }}
+        onCompositionStart={() => {
+          composingRef.current = true;
+          if (timerRef.current) clearTimeout(timerRef.current);
+        }}
+        onCompositionEnd={(e) => {
+          composingRef.current = false;
+          const next = (e.currentTarget as HTMLInputElement).value;
+          setValue(next);
+          scheduleChange(next);
+        }}
+      />
+      {value ? (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={clear}
+          class="absolute inset-y-0 right-3 my-auto flex h-8 w-8 items-center justify-center rounded-full text-neutral-400 transition hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M18 6 6 18"></path>
+            <path d="m6 6 12 12"></path>
+          </svg>
+        </button>
+      ) : null}
+    </div>
   );
 };

--- a/packages/ui/src/SearchBox.tsx
+++ b/packages/ui/src/SearchBox.tsx
@@ -59,7 +59,7 @@ export const SearchBox = ({
       </span>
       <input
         type="search"
-        class="block w-full rounded-2xl border border-neutral-200 bg-white/80 py-3.5 pl-12 pr-12 text-base shadow-sm outline-none backdrop-blur transition placeholder:text-neutral-400 focus:border-sky-400 focus:ring-4 focus:ring-sky-100 dark:border-neutral-800 dark:bg-neutral-900/70 dark:placeholder:text-neutral-500 dark:focus:border-sky-500 dark:focus:ring-sky-500/20"
+        class="block w-full appearance-none rounded-2xl border border-neutral-200 bg-white/80 py-3.5 pl-12 pr-12 text-base shadow-sm outline-none backdrop-blur transition placeholder:text-neutral-400 focus:border-sky-400 focus:ring-4 focus:ring-sky-100 dark:border-neutral-800 dark:bg-neutral-900/70 dark:placeholder:text-neutral-500 dark:focus:border-sky-500 dark:focus:ring-sky-500/20 [&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
         value={value}
         placeholder={placeholder}
         onInput={(e) => {

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,1 +1,9 @@
 @import "tailwindcss";
+
+/*
+ * Tailwind v4 auto-detection skips symlinked node_modules paths, which is
+ * exactly how this package resolves inside consumers (`apps/web` etc.).
+ * Declare our own source root so classes used in these components are
+ * emitted into the consumer's compiled CSS.
+ */
+@source "./**/*.{ts,tsx}";


### PR DESCRIPTION
## Summary
- `/icon/{collection}/{name}.svg` now emits `width="1em" height="1em"`, so icons embedded via `<img>` (e.g. the new preview panel) actually paint. Inline consumers still win via CSS.
- Landing page reworked into a proper product shell: sticky gradient header, hero section, chip-style filters, and a sidebar preview aside — with dark-mode support driven by a small inline theme boot.
- Component-level polish: SearchBox with embedded icon + clear button, FilterBar with pill chips (native checkbox kept for a11y via `peer sr-only`), IconGrid switches to responsive `auto-fill` when no fixed column count is given, IconCell gains hover lift + selection ring, EmptyState + CopyMenu get icons and a new `idle` variant.

## Test plan
- [x] `pnpm typecheck` — clean, `astro check` 0/0/0
- [x] `pnpm lint` — clean
- [x] `pnpm test` — all 6 packages green (18 web, 36 ui, 22 core, 53 ingest, 21 vscode, 6 synonyms)
- [ ] Deploy preview / `pnpm --filter @icon-collection/web dev`, verify:
  - [ ] Hero header renders, gradient shell + sticky header work
  - [ ] Search 'home' → grid populates, live count "1,337 matches"
  - [ ] Clicking a cell opens the right-hand preview aside with a visible SVG (this is what was broken)
  - [ ] Dark mode: toggle system pref → theme flips without flash